### PR TITLE
Add Discord webhook integration and game embed creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Ignore config.ini
+config.ini

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # PrimeWatch
+
+## Project Description
+
+PrimeWatch is a Python script that monitors the Amazon Prime Gaming website for new free game offers and sends notifications to a Discord channel using a webhook. The script extracts the necessary information from the Amazon Prime Gaming website and sends it to the Discord channel in the form of embeds.
+
+### Installation
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/JohnDeved/PrimeWatch.git
+cd PrimeWatch
+```
+
+2. Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Create a `config.ini` file with your Discord webhook URL:
+
+```ini
+[webhook]
+url = YOUR_DISCORD_WEBHOOK_URL
+```
+
+4. Run the script:
+
+```bash
+python watch.py
+```

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[webhook]
+url = https://discord.com/api/webhooks/1319594761073721394/w6KNEUY9lzH3Sol1g52K0WYlPlpj_IccuO4OrRNdgRwDzRLDKhk1TamlBwjSUocBkUdv

--- a/scripts/read_config.sh
+++ b/scripts/read_config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Read the contents of config.ini
+CONFIG_CONTENT=$(cat config.ini)
+
+# Update the GitHub secret with the contents of config.ini
+gh secret set CONFIG_INI -b"$CONFIG_CONTENT"

--- a/scripts/write_config.sh
+++ b/scripts/write_config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Fetch the GitHub secret contents
+GH_SECRET=$(gh secret list | grep CONFIG_INI | awk '{print $1}')
+
+# Write the secret contents to config.ini
+echo "$GH_SECRET" > config.ini


### PR DESCRIPTION
* **watch.py**
  - Import `datetime` and `configparser` libraries
  - Define `load_webhook_url` function to load Discord webhook URL from `config.ini`
  - Define `create_discord_embeds` function to create Discord embeds for each game in the GraphQL response
  - Define `send_to_discord` function to send embeds to the Discord webhook URL
  - Update `main` function to call the new functions and send results to the Discord webhook

* **.gitignore**
  - Add entry to ignore `config.ini`

* **config.ini**
  - Add INI file to store the Discord webhook URL