### PR TITLE
Create a JSON Lines file for past offers

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[webhook]
+url = https://discord.com/api/webhooks/1319594761073721394/w6KNEUY9lzH3Sol1g52K0WYlPlpj_IccuO4OrRNdgRwDzRLDKhk1TamlBwjSUocBkUdv

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,0 @@
-[webhook]
-url = https://discord.com/api/webhooks/1319594761073721394/w6KNEUY9lzH3Sol1g52K0WYlPlpj_IccuO4OrRNdgRwDzRLDKhk1TamlBwjSUocBkUdv

--- a/past_offers
+++ b/past_offers
@@ -1,0 +1,63 @@
+{"id": "amzn1.pg.item.132cb562-d492-4313-90fc-6335eeab7676", "title": "Baldur's Gate II: Enhanced Edition", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.d3295a8d-1dd7-4f0c-a02a-4c0e9932929b", "title": "Morbid: The Seven Acolytes", "startTime": "2024-10-24T17:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.cf7557a9-a65d-49b5-b6e7-b98604150d78", "title": "Coromon", "startTime": "2024-10-31T17:00:00Z", "endTime": "2025-01-29T18:00:00Z"}
+{"id": "amzn1.pg.item.fca09aa1-fa6e-4c47-9843-cedb178ee90f", "title": "Max: The Curse of Brotherhood", "startTime": "2024-11-21T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.a6918af0-b675-4545-9777-dcdec36fb284", "title": "Warhammer 40,000: Dawn of War II", "startTime": "2024-12-12T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.41f7e313-4225-4d71-a0a4-0dea5a6b04d5", "title": "Haunted Hotel: Personal Nightmare - CE", "startTime": "2024-10-31T17:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.81e42040-ac4d-4f12-90f0-5dca1413ed6d", "title": "Tomb Raider: Underworld", "startTime": "2024-12-02T18:00:00Z", "endTime": "2025-01-05T18:00:00Z"}
+{"id": "amzn1.pg.item.63ec17e6-98d6-4a2a-809d-4583c851d8e3", "title": "Hero's Hour", "startTime": "2024-12-12T18:00:00Z", "endTime": "2025-02-12T18:00:00Z"}
+{"id": "amzn1.pg.item.538ee4d5-dbf8-48d9-a835-44062e2acec0", "title": "The Outer Worlds", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-03-05T18:00:00Z"}
+{"id": "amzn1.pg.item.b8184700-cec4-46b6-bab7-1024eff47044", "title": "The Collage Atlas", "startTime": "2024-08-29T17:00:00Z", "endTime": "2025-02-28T18:00:00Z"}
+{"id": "amzn1.pg.item.ea6d2b0c-a00f-4db6-a54e-59e35fb13038", "title": "Spelunky", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.18ebe935-8f05-4932-8b63-40bcc86344f6", "title": "Call of Juarez: Gunslinger", "startTime": "2024-12-02T18:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.pg.item.0c3baf8f-0cd8-414d-bac6-79729c73f473", "title": "Predator: Hunting Grounds", "startTime": "2024-12-19T18:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.47e3beb4-fa93-4141-8bbb-dd75cfbe25c8", "title": "BioShock Remastered", "startTime": "2024-10-10T17:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.953119fd-c18e-4536-9e68-9631d0dec828", "title": "ReDrawn: The Painted Tower - CE", "startTime": "2024-12-12T18:00:00Z", "endTime": "2025-02-12T18:00:00Z"}
+{"id": "amzn1.pg.item.c304fdb8-56db-4471-9678-3955a87b3b24", "title": "The Coma: Recut", "startTime": "2024-12-12T18:00:00Z", "endTime": "2025-01-15T18:00:00Z"}
+{"id": "amzn1.pg.item.140fad39-9af7-4c9c-bba1-a6d4a4b83d99", "title": "Jurassic World Evolution", "startTime": "2024-11-27T18:00:00Z", "endTime": "2025-02-25T18:00:00Z"}
+{"id": "amzn1.pg.item.935352db-da17-4dc0-891c-5f7fcdfbf691", "title": "Monster Train", "startTime": "2024-10-24T17:00:00Z", "endTime": "2025-01-22T18:00:00Z"}
+{"id": "amzn1.pg.item.eb579093-f15f-40f1-ae81-259e4104ac1e", "title": "The Gunk", "startTime": "2024-10-24T17:00:00Z", "endTime": "2025-01-22T18:00:00Z"}
+{"id": "amzn1.pg.item.317f4613-e5ff-4b03-9129-246f32fb8feb", "title": "Ghost Song", "startTime": "2024-09-26T17:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.e4bad3f3-f5e0-484c-b8df-dd2680e4910f", "title": "Mafia: Definitive Edition", "startTime": "2024-11-01T17:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.pg.item.0f9215fa-e5d8-4683-99d5-defc6cd63c68", "title": "Moonscars", "startTime": "2024-11-21T18:00:00Z", "endTime": "2025-02-19T18:00:00Z"}
+{"id": "amzn1.pg.item.26dc4db5-9ad6-4a58-bd73-276adf5411bb", "title": "Elite Dangerous", "startTime": "2024-11-27T18:00:00Z", "endTime": "2025-02-25T18:00:00Z"}
+{"id": "amzn1.pg.item.a7bdaa9f-df98-488e-97af-5322512c05e2", "title": "Baldur's Gate: Enhanced Edition", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.8e9e8e1f-99cd-4997-8526-319fdc387c65", "title": "Nine Witches: Family Disruption", "startTime": "2024-12-19T18:00:00Z", "endTime": "2025-01-02T18:00:00Z"}
+{"id": "amzn1.pg.item.c2739dbe-88cc-43a3-861b-982aa14dbf22", "title": "DREDGE", "startTime": "2024-12-02T18:00:00Z", "endTime": "2025-01-05T18:00:00Z"}
+{"id": "amzn1.pg.item.7c14c6bf-0bc3-41b9-b4a3-34dc1dbd8b1d", "title": "Duck Paradox", "startTime": "2024-11-07T18:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.1683372f-d154-479e-85b9-47f1430ac849", "title": "Mystery Case Files: The Dalimar Legacy - CE", "startTime": "2024-11-27T18:00:00Z", "endTime": "2025-01-28T18:00:00Z"}
+{"id": "amzn1.pg.item.86eb5bf7-ba42-4b3a-a29e-c8d1b0c7acb9", "title": "Star Wars: Bounty Hunter", "startTime": "2024-12-02T18:00:00Z", "endTime": "2024-12-23T18:00:00Z"}
+{"id": "amzn1.pg.item.8a9c12e5-341e-434b-82aa-20f84404409b", "title": "Simulakros", "startTime": "2024-12-19T18:00:00Z", "endTime": "2025-03-19T17:00:00Z"}
+{"id": "amzn1.pg.item.3aebbea1-94fe-4226-8aef-4aa349d655e2", "title": "SCARF", "startTime": "2024-10-17T17:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.c03a78f6-a72e-4ceb-b0a2-5793ce667d51", "title": "Dexter Stardust: Adventures in Outer Space", "startTime": "2024-04-18T17:00:00Z", "endTime": "2025-01-01T06:00:00Z"}
+{"id": "amzn1.adg.product.e13c50c9-d548-4e6f-a85a-7f70308279e8", "title": "Bang Bang Racing", "startTime": "2024-11-07T18:00:00Z", "endTime": "2025-02-05T18:00:00Z"}
+{"id": "amzn1.pg.item.09f5c569-26e3-42e3-8933-13a2e5c9a746", "title": "Planet of Lana", "startTime": "2024-12-12T18:00:00Z", "endTime": "2025-01-15T18:00:00Z"}
+{"id": "amzn1.pg.item.f3867a3a-b3ce-4d33-b43a-aa9192d8dd93", "title": "Faraway 2: Jungle Escape", "startTime": "2024-04-04T17:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.pg.item.ca3a6daa-e68a-4f5a-898f-f7a4cea089c6", "title": "RIOT - Civil Unrest", "startTime": "2024-11-21T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.96e6beeb-913f-4eba-8471-e8188e94b744", "title": "STASIS: BONE TOTEM", "startTime": "2024-10-24T17:00:00Z", "endTime": "2025-01-22T18:00:00Z"}
+{"id": "amzn1.pg.item.34eb9ece-c1c8-42f9-8e18-0bf1c3c8c704", "title": "Scorn", "startTime": "2024-10-31T17:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.pg.item.6fc06cc3-039a-4f6a-b788-100a5fa9c87e", "title": "The Eternal Cylinder", "startTime": "2024-10-03T17:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.4e43dec0-5cc0-43b4-a970-c110605935f6", "title": "The Gap", "startTime": "2024-10-10T17:00:00Z", "endTime": "2025-01-07T18:00:00Z"}
+{"id": "amzn1.pg.item.757cffc7-88f9-433b-965a-207899450dd4", "title": "Quake II", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.acee8e4d-cbd6-4a9e-add2-b3e52d825c51", "title": "Neverwinter Nights: Enhanced Edition", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.95bae0aa-fad6-4c3b-a807-e3053b65c462", "title": "Close to the Sun", "startTime": "2024-11-07T18:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.c832d855-1d1c-4498-8df3-087a45dbd208", "title": "Ms. Holmes: The Case of the Dancing Men - CE", "startTime": "2024-11-14T18:00:00Z", "endTime": "2025-01-15T18:00:00Z"}
+{"id": "amzn1.pg.item.b5c7e9ea-fe6e-44b5-a135-3f6d24ce9e1b", "title": "Electrician Simulator", "startTime": "2024-12-12T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.c3a4b220-2762-416d-ae9c-e849044cc918", "title": "Shogun Showdown", "startTime": "2024-11-27T18:00:00Z", "endTime": "2025-01-28T18:00:00Z"}
+{"id": "amzn1.pg.item.09661e4b-9ac0-4a58-b80b-eaf0b4af8957", "title": "A Plague Tale: Innocence", "startTime": "2024-10-31T17:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.a3efa934-2df6-4142-9cf5-fae055ab84c1", "title": "Aces of the Luftwaffe - Squadron Extended Edition", "startTime": "2024-12-19T18:00:00Z", "endTime": "2025-03-19T17:00:00Z"}
+{"id": "amzn1.pg.item.bbf92539-33a3-48f9-8c4a-68624b1a4987", "title": "Christmas Fables: The Magic Snowflake - CE", "startTime": "2024-12-19T18:00:00Z", "endTime": "2025-01-22T18:00:00Z"}
+{"id": "amzn1.pg.item.261f39ef-7817-4333-9685-913c07486a41", "title": "No Straight Roads", "startTime": "2024-10-03T17:00:00Z", "endTime": "2025-01-01T18:00:00Z"}
+{"id": "amzn1.pg.item.c357e5eb-fddf-44b3-b986-206dcc4247f2", "title": "Faraway: Arctic Escape", "startTime": "2024-04-11T17:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.pg.item.c3112c6d-9286-4a74-96ff-b99607008c37", "title": "Gloomy Tales: One-Way Ticket - CE", "startTime": "2024-11-21T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.a04f8021-81e2-456c-aa16-c0ceb7d8be0d", "title": "Pumpkin Jack", "startTime": "2024-10-24T17:00:00Z", "endTime": "2025-01-22T18:00:00Z"}
+{"id": "amzn1.pg.item.f7492ab7-439e-4e1c-8439-86323c6fc9db", "title": "Through the Darkest of Times", "startTime": "2024-10-17T17:00:00Z", "endTime": "2025-01-15T18:00:00Z"}
+{"id": "amzn1.pg.item.9bc909c7-2bfa-4466-b6a9-5203ee751919", "title": "House of Golf 2", "startTime": "2024-11-14T18:00:00Z", "endTime": "2025-02-12T18:00:00Z"}
+{"id": "amzn1.pg.item.b6910650-0c3f-4d55-b114-71995e792dc3", "title": "Overcooked! 2", "startTime": "2024-12-02T18:00:00Z", "endTime": "2025-01-05T18:00:00Z"}
+{"id": "amzn1.pg.item.c6114db6-8fcd-49d2-8c3c-3747519a78fd", "title": "Overcooked! Gourmet Edition", "startTime": "2024-11-21T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.dc5b4794-e4bf-4f86-870e-d24f1ab2b0b2", "title": "Death's Door", "startTime": "2024-10-31T17:00:00Z", "endTime": "2025-01-29T18:00:00Z"}
+{"id": "amzn1.pg.item.35850bb0-ac60-4455-96cd-c95a1b84c3b1", "title": "Disney•Pixar WALL-E", "startTime": "2024-12-05T15:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.fdd65066-5b10-49d8-9a0d-8cece25399e8", "title": "Super Meat Boy", "startTime": "2024-11-21T18:00:00Z", "endTime": "2024-12-25T18:00:00Z"}
+{"id": "amzn1.pg.item.c90fbab6-a7f2-4e80-8233-632431cf565d", "title": "DreadOut 2", "startTime": "2024-10-10T17:00:00Z", "endTime": "2025-01-08T18:00:00Z"}
+{"id": "amzn1.pg.item.e6dbfe9b-01d8-4b6e-b804-e35656e9d143", "title": "Sir Whoopass: Immortal Death", "startTime": "2024-11-27T18:00:00Z", "endTime": "2024-12-31T18:00:00Z"}
+{"id": "amzn1.adg.product.20b87aa4-24b1-444b-80d0-8a5cbc277c56", "title": "Tiny Robots Recharged", "startTime": "2024-04-25T17:00:00Z", "endTime": "2024-12-31T18:00:00Z"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 gql
 requests_toolbelt
+jsonlines


### PR DESCRIPTION
Add functionality to check past offers and skip sending Discord messages if the offer already exists.

* Add `load_past_offers` and `save_past_offers` functions to handle reading and writing to the JSON Lines file `past_offers`.
* Modify `main` function to check if game items id is in past offers, skip sending Discord message if so, and append to the file otherwise.
* Include the title and offer expiration in the past offers file.
* Log how many offers were posted, if none log "no new offers found".
* Add `jsonlines` module to `requirements.txt`.
* Add `config.ini` file with the provided Discord webhook URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohnDeved/PrimeWatch/pull/3?shareId=b556939e-0e23-48ed-83cb-e8ab46661bc4).