### PR TITLE
Create a GitHub Action to run watch.py every hour

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -1,0 +1,33 @@
+name: Watch
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Create config.ini
+      run: echo "${{ secrets.CONFIG_INI }}" > config.ini
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run watch.py
+      run: python watch.py
+
+    - name: Commit changes
+      run: |
+        git add past_offers
+        git commit -m 'Update past_offers'
+        git push


### PR DESCRIPTION
Add a GitHub Action workflow to run the watch script every hour.

* **Workflow Configuration**
  - Create a new workflow file `.github/workflows/watch.yml`.
  - Schedule the workflow to run every hour using a cron expression.
  - Set up the workflow to run on `ubuntu-latest`.

* **Steps in Workflow**
  - Checkout the repository using `actions/checkout@v2`.
  - Set up Python using `actions/setup-python@v2` with version `3.x`.
  - Create the `config.ini` file from the GitHub secret content.
  - Install the required Python packages using `pip install -r requirements.txt`.
  - Run the `watch.py` script.
  - Commit and push changes to the `past_offers` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohnDeved/PrimeWatch/pull/4?shareId=9ada17aa-8d43-4941-8b2e-910eb2eec1ea).