### PR TITLE
Add manual trigger for the workflow

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -3,6 +3,7 @@ name: Watch
 on:
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:
 
 jobs:
   watch:


### PR DESCRIPTION
Add manual trigger to the workflow.

* Add `workflow_dispatch` to the `on` section in `.github/workflows/watch.yml` to enable manual triggering of the workflow.

